### PR TITLE
Preserve images on gallery-style pages

### DIFF
--- a/lib/ezycopy.js
+++ b/lib/ezycopy.js
@@ -55,6 +55,75 @@ function stripImages(markdown) {
 }
 
 /**
+ * Count images in an HTML string
+ * @param {string} html - HTML content to parse
+ * @returns {number} Number of img elements found
+ */
+function countImagesInHtml(html) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  return doc.querySelectorAll('img').length;
+}
+
+/**
+ * Clean HTML by removing non-content elements (styles, scripts, promos)
+ * @param {Element} container - The container element to clean
+ * @returns {string} Cleaned innerHTML
+ */
+function cleanContainerHtml(container) {
+  // Clone to avoid modifying the actual DOM
+  const clone = container.cloneNode(true);
+
+  // Remove style and script tags
+  clone.querySelectorAll('style, script, noscript').forEach(el => el.remove());
+
+  // Remove common promo/ad patterns
+  const promoSelectors = [
+    '[class*="interlude"]',
+    '[class*="promo"]',
+    '[class*="advert"]',
+    '[class*="sidebar"]',
+    '[class*="related"]',
+    '[class*="newsletter"]',
+    '[class*="subscribe"]',
+    '[id*="promo"]',
+    '[id*="advert"]',
+  ];
+  promoSelectors.forEach(selector => {
+    clone.querySelectorAll(selector).forEach(el => el.remove());
+  });
+
+  return clone.innerHTML;
+}
+
+/**
+ * Find the best content container for fallback extraction
+ * Tries common CMS content selectors before falling back to body
+ * @returns {Element} The content container element
+ */
+function findContentContainer() {
+  // Only use CMS-specific content containers that reliably contain ONLY article content
+  // Avoid generic elements like 'main', 'article' which often include sidebars/related content
+  const selectors = [
+    '.rte',                    // Shopify
+    '.entry-content',          // WordPress
+    '.post-content',           // WordPress alt
+    '.article-content',        // Common CMS pattern
+    '.post-body',              // Blogger/Tumblr
+    '.story-body',             // News sites
+    '.article-body',           // News sites alt
+  ];
+
+  for (const selector of selectors) {
+    const el = document.querySelector(selector);
+    if (el && el.querySelectorAll('img').length > 0) {
+      return el;
+    }
+  }
+  return document.body;
+}
+
+/**
  * Format extracted content for specific output target
  * @param {Object} extraction - Raw extraction result from extractContent()
  * @param {string} target - 'clipboard' or 'download'
@@ -145,6 +214,33 @@ function extractContent(options = {}) {
       isSelection: false,
       html: document.body.outerHTML
     };
+  }
+
+  // Check for significant image loss from Readability processing
+  // Readability strips images when text-to-image ratio is low (gallery pages)
+  // Only fallback if we find a specific content container (not body)
+  const container = findContentContainer();
+  const isSpecificContainer = container !== document.body;
+
+  if (isSpecificContainer) {
+    const containerImageCount = container.querySelectorAll('img').length;
+    const readabilityImageCount = countImagesInHtml(article.content);
+    const imageLossRatio = containerImageCount > 0
+      ? (containerImageCount - readabilityImageCount) / containerImageCount
+      : 0;
+
+    // If >50% images lost from content container, use fallback to preserve images
+    if (imageLossRatio > 0.5) {
+      const cleanedHtml = cleanContainerHtml(container);
+      return {
+        title: article.title,
+        body: turndown.turndown(cleanedHtml),
+        sourceUrl: location.href,
+        byline: article.byline,
+        isSelection: false,
+        html: cleanedHtml
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixed an issue where Readability.js strips images from gallery-style pages (like Shopify stores with many images and little text). Added intelligent fallback logic that detects when >50% of images are lost during content extraction and falls back to direct extraction from CMS-specific containers with cleaning.

## Changes

Added three new helper functions to `lib/ezycopy.js`:

1. **countImagesInHtml()** - Counts images in an HTML string using DOMParser to detect image loss
2. **cleanContainerHtml()** - Strips non-content elements (style tags, scripts, promo/ad elements) before Turndown processes the HTML
3. **findContentContainer()** - Finds CMS-specific content containers (.rte for Shopify, .entry-content for WordPress, etc.) that reliably contain only article content

Modified the **extractContent()** function to add smart fallback logic:
- Detects when Readability strips >50% of images from a specific CMS container
- Falls back to extracting from the CMS container directly with cleaning
- Only triggers for CMS-specific containers, not generic ones like body (prevents false positives on news sites)

## Problem Solved

Readability's heuristic removes images when text-to-image ratio is low (p/img < 0.5). This caused:
- Gallery pages like blambot.com/pages/lettering-tips had all 24 images stripped
- But now detected and falls back to preserve all images
- News sites like BBC and TOI continue to use Readability's clean output (no false positives)
- Promo content and CSS styles are stripped from fallback extraction

## Testing

- Blambot (Shopify gallery): All 24 images now captured
- Times of India: Uses Readability, clean output preserved
- BBC News: Uses Readability, clean output preserved
- Ars Technica: Fallback triggers but CSS/promos are cleaned